### PR TITLE
Make service port configurable for network access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN chmod +x /app/entrypoint.sh
 
 VOLUME ["/models", "/output"]
 
-EXPOSE 7860
+ARG PORT=8000
+ENV PORT=${PORT}
+EXPOSE ${PORT}
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 version: '3.8'
 services:
   sd-api:
-    build: .
+    build:
+      context: .
+      args:
+        PORT: 8000
+    environment:
+      - PORT=8000
     ports:
-      - "7860:7860"
+      - "8000:8000"
     volumes:
       - ./models:/models
       - ./output:/output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-uvicorn app:app --host 0.0.0.0 --port 7860
+uvicorn app:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/start.md
+++ b/start.md
@@ -73,8 +73,8 @@ Option A: Run One Instance
 
 docker-compose up -d
 
-Service will be available at:
-➡️ http://localhost:7860/docs (if using FastAPI)
+Service will be available at (default port **8000**, configurable via `PORT` env variable):
+➡️ http://localhost:8000/docs (if using FastAPI)
 ➡️ or /sdapi/v1/txt2img for POST requests.
 
 Option B: Scale Multiple Instances
@@ -87,7 +87,7 @@ You can then load-balance or assign containers to parallel workloads.
 
 🧪 Example API Call
 
-curl -X POST http://localhost:7860/sdapi/v1/txt2img \
+curl -X POST http://localhost:8000/sdapi/v1/txt2img \
   -H 'Content-Type: application/json' \
   -d '{
     "prompt": "a rustic house with warm lighting, cinematic, wide-angle",


### PR DESCRIPTION
## Summary
- Expose the Stable Diffusion API on a configurable port (default 8000) so other machines on the network can reach it
- Update Dockerfile, compose config, and entrypoint to respect `PORT`
- Refresh documentation to reference the new port and explain usage

## Testing
- `python -m py_compile app.py`
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a932d2cb84832d9ffa11c3f1e1df1f